### PR TITLE
fix: use general gnu mirror url for gsl

### DIFF
--- a/docker/source.Dockerfile
+++ b/docker/source.Dockerfile
@@ -62,7 +62,7 @@ RUN curl -fsSL https://versaweb.dl.sourceforge.net/project/niftilib/nifticlib/ni
 
 # Build and install gsl.
 WORKDIR /src/gsl
-RUN curl -fsSL https://mirror.leifrogers.com/gnu/gsl/gsl-2.5.tar.gz \
+RUN curl -fsSL  https://ftpmirror.gnu.org/gsl/gsl-2.5.tar.gz \
     | tar xz --strip-components 1 \
     && ./configure --prefix=/usr \
     && make -j$NPROC \


### PR DESCRIPTION
The mirror currently in the dockerfile is not available at the moment. This commit uses the more general gnu mirror url, so the best mirror will be found at download time.