### PR TITLE
update murfi docker to use a VNC server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,7 @@
 .dockerignore
+.git
+.idea
+.vagrant
 docker/source.Dockerfile
 docker/Dockerfile
+README.md

--- a/docker/README.md
+++ b/docker/README.md
@@ -16,6 +16,12 @@ docker build --tag murfi2 --file Dockerfile ..
 
 in this directory.
 
+If you run into an error about GPG keys, please make sure that you have enough 
+space for docker to build. On some platforms docker (e.g. OSX) uses a reserved
+space and this gets filled up as you use docker. A complete clearing of this can 
+be done with `docker system prune -a`. However, this will wipe out everything
+in docker.
+
 The former command is recommended. That command builds almost all of murfi's dependencies from source, including dependencies that are not present in the `apt` sources of newer Debian/Ubuntu releases. Building this Docker image will take longer than building with the latter command, but the container should be more reliable. If you receive a `GLXBadContext` error, you should try building with a base image that is similar to your host. The default base image is `ubuntu:18.04`.
 
 The latter command builds murfi on a `debian:jessie` image. Murfi's GUI in this image may not work with your system, because the version of OpenGL in the container must be similar to the version of OpenGL on your host. Debian Jessie has a relatively old version of OpenGL. This image installs all dependencies from the `apt` repositories, and some dependencies are not available in newer releases.

--- a/docker/README.md
+++ b/docker/README.md
@@ -38,7 +38,7 @@ sudo singularity build murfi2.sif docker-daemon://murfi2:latest
 
 Please note the use of `sudo` here. Root access is necessary to interact with the Docker daemon.
 
-## Running the example using the Singularity container
+## Downloading a dataset to run the example
 
 Before running murfi, please download the example data and set environment variables.
 
@@ -47,6 +47,16 @@ curl -fsSL https://dl.dropbox.com/s/1vvrz2g4tbzoh5c/murfi_example_data.tgz | tar
 export MURFI_SUBJECTS_DIR="$PWD"
 export MURFI_SUBJECT_NAME=murfi_example_data
 ```
+
+## Running the example using the Docker container
+
+Using the docker image, you can run murfi in a windowed setting or in
+the background.
+
+TODO
+
+
+## Running the example using the Singularity container
 
 Next, you can run murfi. `murfi2.sif` is the path to the Singularity container, which is a file. The `murfi` bit after the path to the container is the command that is executed within the container. Everything after `murfi` is arguments that are passed to `murfi`.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -53,8 +53,47 @@ export MURFI_SUBJECT_NAME=murfi_example_data
 Using the docker image, you can run murfi in a windowed setting or in
 the background.
 
-TODO
+```
+docker run -it --rm -v $(pwd):/data --name murfi -p 8080:8080 -p 15000:15000 -p 15001:15001 --hostname murfi satra/murfi2
+```
 
+```
+vncserver -SecurityTypes None -xstartup /opt/xstartup :1
+/opt/websockify/websockify.py -v --web /opt/noVNC/ --heartbeat 30 8080 localhost:5901
+```
+
+Open `loclhost:8080` in your browser. The first time you use it, you will be 
+prompted for a password. The default password in the Dockerfile is `murfi123`. 
+Once you are in accept the default message, and then start a terminal. 
+
+```
+cd /data
+export MURFI_SUBJECTS_DIR="$PWD"
+export MURFI_SUBJECT_NAME=murfi_example_data
+murfi -f murfi_example_data/scripts/neurofeedback.xml
+```
+
+To retrieve data from murfi based on the calculations murfi is doing using the 
+ROIs, you can use the communicator test program. Note this test setup has to be 
+started before the next step of sending data to murfi.
+
+```
+cd util/python/communicator
+python test_murfi_communicator.py
+```
+
+Now start a separate docker instance to mimic the scanner.
+
+```
+docker run -it --rm -v $(pwd):/data --name scanner --hostname scanner  satra/murfi2
+```
+
+and then inside the container instance do:
+
+```
+cd /data/murfi_example_data/scripts
+./servedata.sh 3000 15000 host.docker.internal
+```
 
 ## Running the example using the Singularity container
 

--- a/docker/source.Dockerfile
+++ b/docker/source.Dockerfile
@@ -169,7 +169,7 @@ RUN mkdir -p ~/.vnc && \
 
 WORKDIR /home/murfi
 
-CMD ["/src/murfi/bin/murfi"]
+# CMD ["/src/murfi/bin/murfi"]
 
 # vncserver -SecurityTypes None -xstartup /opt/xstartup :1
 # /opt/websockify/websockify.py -v --web /opt/noVNC/ --heartbeat 30 8080 localhost:5901

--- a/docker/source.Dockerfile
+++ b/docker/source.Dockerfile
@@ -42,7 +42,7 @@ RUN apt-get update -qq \
 
 # Build and install Boost (filesystem and system).
 WORKDIR /src/boost
-RUN curl -fsSL https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.gz \
+RUN curl -fsSL https://boostorg.jfrog.io/artifactory/main/release/1.69.0/source/boost_1_69_0.tar.gz \
     | tar xz --strip-components 1 \
     && ./bootstrap.sh \
     && ./b2 -j$NPROC --stagedir=/usr --with-filesystem --with-system \

--- a/util/python/communicator/murfi_activation_communicator.py
+++ b/util/python/communicator/murfi_activation_communicator.py
@@ -32,7 +32,7 @@ class MurfiActivationCommunicator:
         if not self._fake:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.connect((self._ip, self._port))
-            sock.send(mesg)
+            sock.send(mesg.encode())
             resp = sock.recv(4096)
             sock.close()
             return resp
@@ -47,7 +47,7 @@ class MurfiActivationCommunicator:
         to_send = self._roi_query
         to_send = to_send.replace('__TR__', str(tr + 1))
         to_send = to_send.replace('__ROI__', roi_name)
-        resp = self._send(to_send)
+        resp = self._send(to_send).decode()
 
         stripped = re.sub("<.*?>", "", resp)
         try:
@@ -70,7 +70,7 @@ class MurfiActivationCommunicator:
         return self._rois[roi_name]['activation'][tr]
 
     def update(self):
-        for roi_name, roi in self._rois.iteritems():
+        for roi_name, roi in self._rois.items():
             if roi['last_tr'] >= self._num_trs:
                 continue
 

--- a/util/python/communicator/test_murfi_communicator.py
+++ b/util/python/communicator/test_murfi_communicator.py
@@ -8,9 +8,9 @@ from murfi_activation_communicator import MurfiActivationCommunicator
 
 def main(argv):
 
-    roi_names = ['pcc', 'brain-pcc']
+    roi_names = ['active']
     communicator = MurfiActivationCommunicator('localhost',
-                                               15001, 100,
+                                               15001, 85,
                                                roi_names)
 
     while True:
@@ -18,7 +18,7 @@ def main(argv):
 
         for roi in roi_names:
             try:
-                print "%s: %f" % (roi, communicator.get_roi_activation(roi))
+                print(f"{roi}: {communicator.get_roi_activation(roi)}")
             except:
                 pass
 


### PR DESCRIPTION
- updates the docker build with a few source changes
- adds a vnc server to the docker build
- the docker readme is updated with instructions
- the example data works with the docker version

todo
- add a basic psychopy script
- drop vagrant