### PR TITLE
Fixes `docker build` error

### DIFF
--- a/docker/source.Dockerfile
+++ b/docker/source.Dockerfile
@@ -139,7 +139,7 @@ RUN curl -fsSL https://github.com/novnc/noVNC/archive/v${NOVNC_VERSION}.tar.gz |
     mv /opt/noVNC-${NOVNC_VERSION} /opt/noVNC && \
     mv /opt/websockify-${WEBSOCKIFY_VERSION} /opt/websockify && \
     ln -s /opt/noVNC/vnc_lite.html /opt/noVNC/index.html && \
-    cd /opt && curl -sSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+    cd /opt && curl -sSL https://bootstrap.pypa.io/pip/3.6/get-pip.py -o get-pip.py && \
     python3 get-pip.py && \
     cd /opt/websockify && pip install . && make
 


### PR DESCRIPTION
Building the docker container:
```
git clone git@github.com:gablab/murfi2.git
cd ./murfi2/docker/
docker build -t pwighton/murfi2:20220822 --file source.Dockerfile ..
```

Was giving the following error:
```
ERROR: This script does not work on Python 3.6 The minimum supported Python version is 3.7. Please use https://bootstrap.pypa.io/pip/3.6/get-pip.py instead
```

This changes the URL of the get-pip script accordingly