### PR TITLE
Run the release build action on tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   release:
-    if: startsWith(github.ref, 'refs/heads/master')
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Don't block on master, that's not how tags work